### PR TITLE
Fix Student Delete command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,8 +14,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_TEST = "This test already exists in the address book";
     public static final String MESSAGE_INVALID_PARENT_DISPLAYED_NUMBER =
             "The parent number provided is invalid/ not found";
-    public static final String MESSAGE_INVALID_PARENT_DELETE = "The parent you are trying to delete has a" +
-            "student attached! You can't delete the parent!";
-    public static final String MESSAGE_INVALID_PARENT_NAME = "The parent name provided does not match the " +
-            "parent name attached to given phone number.";
+    public static final String MESSAGE_INVALID_PARENT_DELETE = "The parent you are trying to delete has a"
+            + "student attached! You can't delete the parent!";
+    public static final String MESSAGE_INVALID_PARENT_NAME = "The parent name provided does not match the "
+            + "parent name attached to given phone number.";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,7 +12,10 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_HOMEWORK = "This homework already exists in the address book";
     public static final String MESSAGE_DUPLICATE_TEST = "This test already exists in the address book";
-
     public static final String MESSAGE_INVALID_PARENT_DISPLAYED_NUMBER =
             "The parent number provided is invalid/ not found";
+    public static final String MESSAGE_INVALID_PARENT_DELETE = "The parent you are trying to delete has a" +
+            "student attached! You can't delete the parent!";
+    public static final String MESSAGE_INVALID_PARENT_NAME = "The parent name provided does not match the " +
+            "parent name attached to given phone number.";
 }

--- a/src/main/java/seedu/address/logic/commands/parent/ParentAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/parent/ParentAddCommand.java
@@ -11,7 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONEPARENT;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.DuplicateParentException;
 import seedu.address.model.person.parent.Parent;
 
 /**
@@ -56,7 +56,7 @@ public class ParentAddCommand extends ParentCommand {
         requireNonNull(model);
 
         if (model.hasParent(parent)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateParentException();
         }
 
         model.addParent(parent);

--- a/src/main/java/seedu/address/logic/commands/parent/ParentDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/parent/ParentDeleteCommand.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.parent.Parent;
 
@@ -44,12 +45,14 @@ public class ParentDeleteCommand extends ParentCommand {
     public static final String MESSAGE_DELETE_PARENT_SUCCESS = "Deleted Parent: %1$s";
 
     private final Phone phoneNumber;
+    private final Name parentName;
 
     /**
      * Creates a ParentDeleteCommand to delete the specified {@code Parent}
      */
-    public ParentDeleteCommand(Phone phoneNumber) {
+    public ParentDeleteCommand(Name parentName, Phone phoneNumber) {
         this.phoneNumber = phoneNumber;
+        this.parentName = parentName;
     }
 
     @Override
@@ -58,6 +61,12 @@ public class ParentDeleteCommand extends ParentCommand {
         ObservableList<Parent> parents = model.getFilteredParentList();
         for (Parent parent : parents) {
             if (parent.getPhone().equals(phoneNumber)) {
+                if (parent.hasStudents()) {
+                    throw new CommandException(Messages.MESSAGE_INVALID_PARENT_DELETE);
+                }
+                if (!parent.getName().equals(parentName)) {
+                    throw new CommandException(Messages.MESSAGE_INVALID_PARENT_NAME);
+                }
                 model.deleteParent(parent);
                 return new CommandResult(String.format(MESSAGE_DELETE_PARENT_SUCCESS, parent));
             }

--- a/src/main/java/seedu/address/logic/commands/student/StudentAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/student/StudentAddCommand.java
@@ -33,7 +33,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Image;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.DuplicateStudentException;
 import seedu.address.model.person.parent.Parent;
 import seedu.address.model.person.student.Student;
 import seedu.address.model.tag.Tag;
@@ -100,15 +100,13 @@ public class StudentAddCommand extends StudentCommand {
         requireNonNull(model);
 
         if (model.hasStudent(toAdd)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateStudentException();
         }
         /*
         if (!model.canInitialize(toAdd.getParentNumber(), toAdd.getParentName())) {
             throw new DuplicatePhoneException();
         }
-
          */
-
         model.addStudent(toAdd, toAdd.getStudentClass());
         ObservableList<Parent> parents = model.getFilteredParentList();
         setParent(parents, toAdd, model);

--- a/src/main/java/seedu/address/logic/parser/ParentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ParentCommandParser.java
@@ -106,7 +106,8 @@ public class ParentCommandParser {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ParentDeleteCommand.MESSAGE_USAGE));
         }
         Phone phoneNumber = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONEPARENT).get());
-        return new ParentDeleteCommand(phoneNumber);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        return new ParentDeleteCommand(name, phoneNumber);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateParentException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateParentException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Parents (Parents are considered duplicates if they have the same
+ * phone number).
+ */
+public class DuplicateParentException extends RuntimeException {
+    public DuplicateParentException() {
+        super("ERROR, operation would result in duplicate parents!");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateStudentException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateStudentException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Students (Students are considered duplicates if they have the
+ * same name & class & index number).
+ */
+public class DuplicateStudentException extends RuntimeException {
+    public DuplicateStudentException() {
+        super("ERROR, operation would result in duplicate students!");
+    }
+}

--- a/src/main/java/seedu/address/model/person/parent/Parent.java
+++ b/src/main/java/seedu/address/model/person/parent/Parent.java
@@ -74,8 +74,17 @@ public class Parent extends Person {
      *
      * @return All Students that the Parent / NOK has relations to.
      */
-    public List<Student> getChildren() {
+    public List<Student> getStudents() {
         return children;
+    }
+
+    /**
+     * A boolean method that checks if the current Parent / NOK has students attached to him / her.
+     *
+     * @return Boolean value indicating if there is at least one Student attached to this Parent.
+     */
+    public boolean hasStudents() {
+        return (children.size() > 0);
     }
 
     /**
@@ -124,7 +133,7 @@ public class Parent extends Person {
                 && otherParent.getEmail().equals(getEmail())
                 && otherParent.getAddress().equals(getAddress())
                 && otherParent.getTags().equals(getTags())
-                && otherParent.getChildren().equals(getChildren());
+                && otherParent.getStudents().equals(getStudents());
     }
 
     @Override
@@ -144,7 +153,7 @@ public class Parent extends Person {
                 .append(getPhone())
                 .append("; Parent/NOK of:");
 
-        List<Student> children = getChildren();
+        List<Student> children = getStudents();
         for (Student child : children) {
             builder.append(" ")
                     .append(child);

--- a/src/main/java/seedu/address/model/person/parent/UniqueParentList.java
+++ b/src/main/java/seedu/address/model/person/parent/UniqueParentList.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.DuplicateParentException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
@@ -34,7 +34,7 @@ public class UniqueParentList implements Iterable<Parent> {
     public void add(Parent toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateParentException();
         }
         internalList.add(toAdd);
     }
@@ -53,7 +53,7 @@ public class UniqueParentList implements Iterable<Parent> {
         }
 
         if (!target.isSamePerson(editedParent) && contains(editedParent)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateParentException();
         }
 
         internalList.set(index, editedParent);
@@ -82,7 +82,7 @@ public class UniqueParentList implements Iterable<Parent> {
     public void setParents(List<Parent> parents) {
         requireAllNonNull(parents);
         if (!parentsAreUnique(parents)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateParentException();
         }
         internalList.setAll(parents);
     }

--- a/src/main/java/seedu/address/model/person/student/UniqueStudentList.java
+++ b/src/main/java/seedu/address/model/person/student/UniqueStudentList.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.DuplicateStudentException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
@@ -34,7 +34,7 @@ public class UniqueStudentList implements Iterable<Student> {
     public void add(Student toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateStudentException();
         }
         internalList.add(toAdd);
     }
@@ -53,7 +53,7 @@ public class UniqueStudentList implements Iterable<Student> {
         }
 
         if (!target.isSamePerson(editedStudent) && contains(editedStudent)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateStudentException();
         }
 
         internalList.set(index, editedStudent);
@@ -82,7 +82,7 @@ public class UniqueStudentList implements Iterable<Student> {
     public void setStudents(List<Student> students) {
         requireAllNonNull(students);
         if (!studentsAreUnique(students)) {
-            throw new DuplicatePersonException();
+            throw new DuplicateStudentException();
         }
 
         internalList.setAll(students);

--- a/src/main/java/seedu/address/storage/person/JsonAdaptedParent.java
+++ b/src/main/java/seedu/address/storage/person/JsonAdaptedParent.java
@@ -52,7 +52,7 @@ public class JsonAdaptedParent extends JsonAdaptedPerson {
         super(parent);
         this.age = parent.getAge().value;
         this.image = parent.getImage().value;
-        for (Student student : parent.getChildren()) {
+        for (Student student : parent.getStudents()) {
             children.add(new JsonAdaptedStudent(student));
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,8 +17,10 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.exceptions.DuplicateParentException;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.DuplicatePhoneException;
+import seedu.address.model.person.exceptions.DuplicateStudentException;
 import seedu.address.model.person.student.Student;
 import seedu.address.model.person.student.UniqueStudentList;
 import seedu.address.ui.parent.ParentListPanel;
@@ -242,6 +244,14 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Duplicate phone number: " + commandText);
             resultDisplay.setFeedbackToUser(dp.getMessage());
             throw dp;
+        } catch (DuplicateStudentException dse) {
+            logger.info("Duplicate student: " + commandText);
+            resultDisplay.setFeedbackToUser(dse.getMessage());
+            throw dse;
+        } catch (DuplicateParentException dpe) {
+            logger.info("Duplicate parent: " + commandText);
+            resultDisplay.setFeedbackToUser(dpe.getMessage());
+            throw dpe;
         }
     }
 }

--- a/src/main/java/seedu/address/ui/parent/ParentCard.java
+++ b/src/main/java/seedu/address/ui/parent/ParentCard.java
@@ -61,7 +61,7 @@ public class ParentCard extends UiPart<Region> {
         parent.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        parent.getChildren().stream()
+        parent.getStudents().stream()
                 .sorted(Comparator.comparing(Student -> Student.getName().fullName))
                 .forEach(Student -> {
                     students.getChildren().add(new Label(" Student Name: "));


### PR DESCRIPTION
Fix Student Delete command
- Users cannot delete parent that have students attached
- Users need to have matching Phone Number and Name for the Parent
they are trying to delete
- Add MESSAGE_INVALID_PARENT_DELETE and MESSAGE_INVALID_PARENT_NAME
to display to users the respective error messages

Add DuplicateParentException.java and DuplicateStudentException.java
- Instead of showing duplicate person error messages for both
student and parent, display individual messages for student and
parent

READY TO MERGE!