### PR TITLE
PARTIAL FIX of StudentEditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/student/StudentAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/student/StudentAddCommand.java
@@ -77,8 +77,8 @@ public class StudentAddCommand extends StudentCommand {
             + PREFIX_IMAGESTUDENT + "C:// "
             + PREFIX_EMAILSTUDENT + "tanahcow@gmail.com "
             + PREFIX_PHONESTUDENT + "91234567 "
-            + PREFIX_CCA + "Captain Ball"
-            + PREFIX_ATTENDANCE + "T";
+            + PREFIX_CCA + "Captain Ball "
+            + PREFIX_ATTENDANCE + "T ";
 
     public static final String MESSAGE_SUCCESS = "New student added:";
 
@@ -156,5 +156,6 @@ public class StudentAddCommand extends StudentCommand {
             throw new DuplicateParentException();
         }
         model.addParent(newParent);
+        student.setParent(newParent);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -37,9 +37,9 @@ public class ArgumentMultimap {
     public Optional<String> getValue(Prefix prefix) {
         if (!argMultimap.containsKey(prefix)) {
             switch(prefix.getPrefix()) {
-            case "n/":
-                Optional<String> missingName = Optional.of("Insert new name here!");
-                return missingName;
+            //case "n/":
+            //    Optional<String> missingName = Optional.of("Insert new name here!");
+            //    return missingName;
             case "rls/":
                 Optional<String> missingRelationship = Optional.of("Insert parent relationship to student here!");
                 return missingRelationship;

--- a/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
@@ -333,7 +333,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StudentEditCommand.MESSAGE_USAGE));
         }
 
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        //Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Name newName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NEWNAME).get());
         Phone newStudentPhoneNumber = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONESTUDENT).get());
         Email newEmail = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAILSTUDENT).get());
@@ -353,7 +353,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
         Phone newParentPhoneNumber = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONEPARENT).get());
         Relationship newRelationship = ParserUtil.parseRelationship(argMultimap.getValue(PREFIX_RELATIONSHIP).get());
 
-        return new StudentEditCommand(name, newName, indexNumber, newIndexNumber, studentClass, newStudentClass, newSex,
+        return new StudentEditCommand(newName, indexNumber, newIndexNumber, studentClass, newStudentClass, newSex,
                 newParentPhoneNumber, newParentName, newRelationship, newAge, newImage, newCca,
                 newComment, newStudentPhoneNumber, newEmail, newAddress, newTagList);
     }


### PR DESCRIPTION
Found out error in ParentEditCommand arose due to presence of case "n/" in ArgumentMultimap.java, after commenting out the case "n/", StudentEditCommand had errors, hence tried to fix StudentEditCommand, realise some slight error in StudentEditCommand...

Things done:
1. Remove case "n/" from ArgumentMultimap.java as it should not be optional and it is not used for StudentEditCommand
2. Fix StudentAddCommand.java display message spacing and minor error in setting the Parent for the Student
3. Fix StudentCommandParser.java by removing name from StudentEditCommand() as it is not used at all
4. Partial FIX of StudentEditCommand.java

Notes:
- There is some error in the logic of StudentEditCommand
- When editing Student particulars, if Parent Name and Parent Number not changed, simply update the Student and update the Parent binded with the Student so that the Parent has updated Student info
- If Parent Name change but Parent Number same, FOR ALL STUDENTS under the parent, need to update the parent given for the students with the new updated parent name.
- If different parent number from original student's parent number, remove binding of the original student from the parent and bind the new student to the parent with the NEW PARENT NUMBER
- If parent number not found in parent list, CREATE a new parent and perform binding of parent and student just like how StudentAddCommand does.

READY TO MERGE, send some help in the fix pleaseee with tips from "Notes"!