### PR TITLE
Fix issues pertaining to parent command in particular relationship aspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
   * It is **written in OOP fashion**. It provides a **reasonably well-written** code base **bigger** (around 6 KLoC) than what students usually write in beginner-level SE modules, without being overwhelmingly big.
   * It comes with a **reasonable level of user and developer documentation**.
 * It is named `PowerConnect` (`PC` for short) because it provides teacher a powerful application to connect with their students.
-* For the detailed documentation of this project, see the **[Address Book Product Website](https://se-education.org/addressbook-level3)**.
+* For the detailed documentation of this project, see the **[PowerConnect Website](https://mrtwit99.github.io/PowerConnect/)**.
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -25,4 +25,8 @@ public class Messages {
 
     public static final String MESSAGE_INVALID_WEIGHTAGE =
             "Error! The weightage should add up to less than or equals to 100%";
+    public static final String MESSAGE_RELATIONSHIP_NOT_FOUND = "The relationship of the parent/NOK to the student "
+            + "cannot be found! Please re-enter with the relationship!";
+    public static final String MESSAGE_PARENT_NAME_NOT_FOUND = "Missing name for parent/NOK! Please re-enter with "
+            + "the corresponding name!";
 }

--- a/src/main/java/seedu/address/logic/commands/student/StudentEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/student/StudentEditCommand.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/commands/student/StudentEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/student/StudentEditCommand.java
@@ -13,8 +13,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWINDEXNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWPARENTNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWPHONEPARENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWRELATIONSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONESTUDENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTAGE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -72,7 +73,7 @@ public class StudentEditCommand extends StudentCommand {
             + PREFIX_ADDRESS + "ADDRESS "
             + PREFIX_NEWPARENTNAME + "PARENT NAME "
             + PREFIX_NEWPHONEPARENT + "PARENT PHONE NUMBER "
-            + PREFIX_RELATIONSHIP + "RELATIONSHIP "
+            + PREFIX_NEWRELATIONSHIP + "RELATIONSHIP "
             + "]\n"
             + "Example: \n" + "student 1A " + COMMAND_WORD + " "
             + PREFIX_INDEXNUMBER + "02 "
@@ -89,7 +90,7 @@ public class StudentEditCommand extends StudentCommand {
             + PREFIX_ADDRESS + "Blk 245 Ang Mo Kio Avenue 1 #11-800 S(560245) "
             + PREFIX_NEWPARENTNAME + "Tan Ah Seng "
             + PREFIX_NEWPHONEPARENT + "98989898 "
-            + PREFIX_RELATIONSHIP + "FATHER";
+            + PREFIX_NEWRELATIONSHIP + "FATHER";
 
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited student: %1$s; Class: %2$s; Index Number: %3$s;";
 
@@ -165,7 +166,7 @@ public class StudentEditCommand extends StudentCommand {
     /**
      * Creates and returns a {@code Student} with the details of {@code student}
      */
-    public Student createEditedStudent(Student student) {
+    public Student createEditedStudent(Student student) throws CommandException {
         if (Name.isDefaultName(newName.fullName)) {
             this.newName = student.getName();
         }
@@ -177,6 +178,16 @@ public class StudentEditCommand extends StudentCommand {
         }
         if (Phone.isDefaultPhone(newParentPhoneNumber.value)) {
             this.newParentPhoneNumber = student.getParentNumber();
+        } else {
+            if (Relationship.isDefaultRelationship(newRelationship.rls)) {
+                throw new CommandException(Messages.MESSAGE_RELATIONSHIP_NOT_FOUND);
+            }
+            if (Name.isDefaultName(newParentName.fullName)) {
+                throw new CommandException(Messages.MESSAGE_PARENT_NAME_NOT_FOUND);
+            }
+        }
+        if (Relationship.isDefaultRelationship(newRelationship.rls)) {
+            this.newRelationship = student.getRls();
         }
         if (Phone.isDefaultPhone(newStudentPhoneNumber.value)) {
             this.newStudentPhoneNumber = student.getPhone();
@@ -201,9 +212,6 @@ public class StudentEditCommand extends StudentCommand {
         }
         if (Sex.isDefaultSex(newSex.value)) {
             this.newSex = student.getSex();
-        }
-        if (Relationship.isDefaultRelationship(newRelationship.rls)) {
-            this.newRelationship = student.getRls();
         }
         if (Name.isDefaultName(newParentName.fullName)) {
             this.newParentName = student.getParentName();
@@ -249,8 +257,7 @@ public class StudentEditCommand extends StudentCommand {
         ObservableList<Parent> parents = model.getFilteredParentList();
         if (student.getParentName() != oldStudent.getParentName()) { // Parent changed his/her name
             for (Parent p : parents) {
-                if ((p.getPhone().equals(oldStudent.getParentNumber())) && (p.getName().equals(
-                        oldStudent.getParentName()))) {
+                if (p.getPhone().equals(oldStudent.getParentNumber())) {
                     Parent newParent = new Parent(student.getParentName(), p.getAge(), p.getImage(), p.getEmail(),
                             p.getPhone(), p.getAddress(), p.getTags());
                     newParent = editParent(p, newParent, model);
@@ -263,7 +270,7 @@ public class StudentEditCommand extends StudentCommand {
         Phone parentNumber = student.getParentNumber();
         Name parentName = student.getParentName();
         for (Parent p : parents) { // Parent did not change any particulars
-            if ((p.getPhone().equals(parentNumber)) && (p.getName().equals(parentName))) {
+            if (p.getPhone().equals(parentNumber)) {
                 student.setParent(p);
                 Parent newParent = p;
                 newParent.addStudent(student); //bind student to parent
@@ -287,8 +294,7 @@ public class StudentEditCommand extends StudentCommand {
     public Student changeParent(Student student, Model model, Student oldStudent) {
         ObservableList<Parent> parents = model.getFilteredParentList();
         for (Parent p : parents) {
-            if ((p.getPhone().equals(oldStudent.getParentNumber())) && (p.getName().equals(
-                    oldStudent.getParentName()))) {
+            if (p.getPhone().equals(oldStudent.getParentNumber())) {
                 if (p.getStudents().size() == 1) { // Removes parent if this is the only student binded to him/her
                     model.deleteParent(p);
                 } else { // Remove student binding to original parent
@@ -297,8 +303,7 @@ public class StudentEditCommand extends StudentCommand {
                     model.setParent(originalParent, p);
                 }
                 for (Parent np : parents) { // Locating new parent in existing parents
-                    if ((np.getPhone().equals(student.getParentNumber())) && (np.getName().equals(
-                            student.getParentName()))) {
+                    if (np.getPhone().equals(student.getParentNumber())) {
                         student.setParent(np);
                         Parent newParent = np;
                         np.addStudent(student);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -37,7 +37,7 @@ public class ArgumentMultimap {
     public Optional<String> getValue(Prefix prefix) {
         if (!argMultimap.containsKey(prefix)) {
             switch(prefix.getPrefix()) {
-            case "rls/":
+            case "nrls/":
                 Optional<String> missingRelationship = Optional.of("Insert parent relationship to student here!");
                 return missingRelationship;
             case "s/":

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -33,6 +33,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONESTUDENT = new Prefix("pnS/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_RELATIONSHIP = new Prefix("rls/");
+    public static final Prefix PREFIX_NEWRELATIONSHIP = new Prefix("nrls/");
     public static final Prefix PREFIX_SEX = new Prefix("s/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_TEST = new Prefix("test/");

--- a/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StudentCommandParser.java
@@ -27,6 +27,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWINDEXNUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWPARENTNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWPHONEPARENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEWRELATIONSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PARENTNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONEPARENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONESTUDENT;
@@ -166,7 +167,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
      */
     private ArgumentMultimap getArgEdit(String arguments) {
         return ArgumentTokenizer.tokenize(arguments, PREFIX_EDIT, PREFIX_NAME, PREFIX_INDEXNUMBER, PREFIX_SEX,
-                PREFIX_NEWPARENTNAME, PREFIX_NEWPHONEPARENT, PREFIX_RELATIONSHIP, PREFIX_STUDENTAGE,
+                PREFIX_NEWPARENTNAME, PREFIX_NEWPHONEPARENT, PREFIX_NEWRELATIONSHIP, PREFIX_STUDENTAGE,
                 PREFIX_IMAGESTUDENT, PREFIX_EMAILSTUDENT, PREFIX_PHONESTUDENT, PREFIX_CCA, PREFIX_ADDRESS,
                 PREFIX_NEWCLASS, PREFIX_NEWINDEXNUMBER, PREFIX_NEWNAME, PREFIX_COMMENT);
 
@@ -451,7 +452,7 @@ public class StudentCommandParser implements Parser<StudentCommand> {
         Comment newComment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get());
         Name newParentName = ParserUtil.parseName(argMultimap.getValue(PREFIX_NEWPARENTNAME).get());
         Phone newParentPhoneNumber = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_NEWPHONEPARENT).get());
-        Relationship newRelationship = ParserUtil.parseRelationship(argMultimap.getValue(PREFIX_RELATIONSHIP).get());
+        Relationship newRelationship = ParserUtil.parseRelationship(argMultimap.getValue(PREFIX_NEWRELATIONSHIP).get());
         return new StudentEditCommand(newName, indexNumber, newIndexNumber, studentClass, newStudentClass, newSex,
                 newParentPhoneNumber, newParentName, newRelationship, newAge, newImage, newCca,
                 newComment, newStudentPhoneNumber, newEmail, newAddress);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -120,7 +120,6 @@ public class Person {
 
         if (otherPerson instanceof Parent) {
             return otherPerson != null
-                    && otherPerson.getName().equals(getName())
                     && otherPerson.getPhone().equals(getPhone());
         }
 

--- a/src/main/java/seedu/address/model/person/parent/Parent.java
+++ b/src/main/java/seedu/address/model/person/parent/Parent.java
@@ -134,7 +134,9 @@ public class Parent extends Person {
         }
 
         Parent otherParent = (Parent) other;
-        return otherParent.getName().equals(getName())
+        return otherParent.getPhone().equals(getPhone())
+                && otherParent.getName().equals(getName());
+        /*return otherParent.getName().equals(getName())
                 && otherParent.getAge().equals(getAge())
                 && otherParent.getImage().equals(getImage())
                 && otherParent.getPhone().equals(getPhone())
@@ -142,6 +144,7 @@ public class Parent extends Person {
                 && otherParent.getAddress().equals(getAddress())
                 && otherParent.getTags().equals(getTags())
                 && otherParent.getStudents().equals(getStudents());
+         */
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/parent/Parent.java
+++ b/src/main/java/seedu/address/model/person/parent/Parent.java
@@ -134,9 +134,7 @@ public class Parent extends Person {
         }
 
         Parent otherParent = (Parent) other;
-        return otherParent.getPhone().equals(getPhone())
-                && otherParent.getName().equals(getName());
-        /*return otherParent.getName().equals(getName())
+        return otherParent.getName().equals(getName())
                 && otherParent.getAge().equals(getAge())
                 && otherParent.getImage().equals(getImage())
                 && otherParent.getPhone().equals(getPhone())
@@ -144,7 +142,6 @@ public class Parent extends Person {
                 && otherParent.getAddress().equals(getAddress())
                 && otherParent.getTags().equals(getTags())
                 && otherParent.getStudents().equals(getStudents());
-         */
     }
 
     @Override

--- a/src/test/java/seedu/address/model/parent/ParentTest.java
+++ b/src/test/java/seedu/address/model/parent/ParentTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AGE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_QUIET;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -81,21 +80,24 @@ public class ParentTest {
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
-        editedAlice = new ParentBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        // (REMOVED as no Parent/NOK can share same number with another Parent/NOK!)
+        //editedAlice = new ParentBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        //assertFalse(ALICE.isSamePerson(editedAlice));
 
         // different phone number, all other attributes same -> returns false
         editedAlice = new ParentBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns false
-        Person editedBob = new ParentBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // (REMOVED as no Parent/NOK can share same number with another Parent/NOK!)
+        //Person editedBob = new ParentBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        //assertFalse(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new ParentBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // (REMOVED as no Parent/NOK can share same number with another Parent/NOK!)
+        // String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
+        // editedBob = new ParentBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        // assertFalse(BOB.isSamePerson(editedBob));
     }
 
     @Test
@@ -117,11 +119,12 @@ public class ParentTest {
         assertFalse(ALICE.equals(BOB));
 
         // different name -> returns false
-        Person editedAlice = new ParentBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        // (REMOVED as no Parent/NOK can share same number with another Parent/NOK!)
+        // Person editedAlice = new ParentBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // assertFalse(ALICE.equals(editedAlice));
 
         // different age -> returns false
-        editedAlice = new ParentBuilder(ALICE).withAge(VALID_AGE_BOB).build();
+        Parent editedAlice = new ParentBuilder(ALICE).withAge(VALID_AGE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different phone -> returns false


### PR DESCRIPTION
Fix Student Edit Command issues pertaining to editing of parent details

Add error messages for missing parent/NOK name, missing relationship for student edit command

Add new PREFIX for new relationship to differentiate it from relationship to fix Student Add Command issue where user is able to input a new student without parent relationship detail

Fix Person.isSamePerson() for Parent instances